### PR TITLE
Document CDP browser sessions

### DIFF
--- a/content/docs/browser-sessions-overview.mdx
+++ b/content/docs/browser-sessions-overview.mdx
@@ -85,6 +85,53 @@ curl -X DELETE "https://api.capture.page/v1/sessions/{sessionId}" \
   -H "Authorization: Bearer <token>"
 ```
 
+## Connect over CDP
+
+When you need direct Chrome DevTools Protocol access, create the session with
+`cdp: true`. Capture returns a `connectUrl` that CDP clients can use to attach
+to the same cloud browser.
+
+```bash
+curl -X POST "https://api.capture.page/v1/sessions" \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{"cdp":true,"maxTtlSeconds":300}'
+```
+
+Use the returned `session.connectUrl` with a CDP client such as Puppeteer or
+Playwright:
+
+```ts
+import puppeteer from "puppeteer";
+
+const browser = await puppeteer.connect({
+  browserWSEndpoint: session.connectUrl,
+});
+```
+
+```ts
+import { chromium } from "playwright";
+
+const browser = await chromium.connectOverCDP(session.connectUrl);
+```
+
+`connectUrl` values are minted fresh and are only returned for active
+CDP-enabled sessions. If a client disconnects and you need to reconnect, fetch
+the session again while it is active:
+
+```bash
+curl "https://api.capture.page/v1/sessions/{sessionId}" \
+  -H "Authorization: Bearer <token>"
+```
+
+Disconnecting a CDP client does not close the Capture session. Close the
+session with `DELETE /v1/sessions/{sessionId}` when the workflow is finished so
+billing stops promptly.
+
+CDP sessions cannot be combined with `proxy` or `bypassBotDetection`. If you
+need either of those options, create a regular browser session and use Capture
+actions instead of a raw CDP connection.
+
 ## Action types
 
 Actions are deterministic operations executed inside the active session page.

--- a/content/docs/mcp-integration.mdx
+++ b/content/docs/mcp-integration.mdx
@@ -134,10 +134,21 @@ A session keeps a real browser open and is billed by duration — **1 credit per
 #### browser_session_create
 
 Start an interactive browser session. Returns a `sessionId` and `expiresAt`.
+When `cdp: true` is set, it also returns a `connectUrl` for external CDP
+clients.
 
 - Optional `maxTtlSeconds` (max 900) to cap the session lifetime
 - Optional `proxy` to route through your configured proxy
 - Optional `bypassBotDetection` to use a stealth browser
+- Optional `cdp` to expose a Chrome DevTools Protocol connection URL
+
+Use `cdp: true` when an external automation client needs to attach directly to
+the browser. Pass the returned `connectUrl` to Puppeteer `connect` or
+Playwright `connectOverCDP`, then close the Capture session with
+`browser_session_close` when finished. Disconnecting the CDP client does not
+close the Capture session.
+
+`cdp` cannot be combined with `proxy` or `bypassBotDetection`.
 
 #### browser_session_act
 

--- a/public/openapi/sessions.yaml
+++ b/public/openapi/sessions.yaml
@@ -50,6 +50,10 @@ paths:
               customTtl:
                 value:
                   maxTtlSeconds: 300
+              cdp:
+                value:
+                  maxTtlSeconds: 300
+                  cdp: true
               proxyAndBypass:
                 value:
                   maxTtlSeconds: 300
@@ -62,6 +66,36 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CreateSessionResponse'
+              examples:
+                default:
+                  value:
+                    success: true
+                    session:
+                      id: sess_123e4567-e89b-12d3-a456-426614174000
+                      status: active
+                      expiresAt: '2026-06-17T11:20:00.000Z'
+                      maxTtlSeconds: 300
+                      proxy: false
+                      bypassBotDetection: false
+                      cdp: false
+                cdp:
+                  value:
+                    success: true
+                    session:
+                      id: sess_123e4567-e89b-12d3-a456-426614174000
+                      status: active
+                      expiresAt: '2026-06-17T11:20:00.000Z'
+                      maxTtlSeconds: 300
+                      proxy: false
+                      bypassBotDetection: false
+                      cdp: true
+                      connectUrl: wss://connect.capture.page/cdp?token=v1.example
+        '400':
+          description: Invalid session options
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -339,6 +373,14 @@ components:
           type: boolean
           default: false
           description: Use Capture's configured captcha/bot-detection bypass browser when available.
+        cdp:
+          type: boolean
+          default: false
+          description: |
+            Expose a Chrome DevTools Protocol connection URL for direct browser
+            automation clients. CDP sessions cannot be combined with `proxy` or
+            `bypassBotDetection`. The create response includes `session.cdp`;
+            session metadata includes `session.options.cdp`.
 
     CreateSessionResponse:
       allOf:
@@ -348,7 +390,7 @@ components:
           properties:
             session:
               type: object
-              required: [id, status, expiresAt, maxTtlSeconds, proxy, bypassBotDetection]
+              required: [id, status, expiresAt, maxTtlSeconds, proxy, bypassBotDetection, cdp]
               properties:
                 id:
                   type: string
@@ -363,6 +405,16 @@ components:
                   type: boolean
                 bypassBotDetection:
                   type: boolean
+                cdp:
+                  type: boolean
+                  description: Whether this session exposes a CDP connection.
+                connectUrl:
+                  type: string
+                  format: uri
+                  description: |
+                    Fresh WebSocket URL for active CDP-enabled sessions. Use
+                    this with clients such as Puppeteer `connect` or Playwright
+                    `connectOverCDP`.
 
     GetSessionResponse:
       allOf:
@@ -438,6 +490,16 @@ components:
               type: boolean
             bypassBotDetection:
               type: boolean
+            cdp:
+              type: boolean
+              description: Whether this session exposes a CDP connection.
+        connectUrl:
+          type: string
+          format: uri
+          description: |
+            Fresh WebSocket URL returned only while a CDP-enabled session is
+            active. Client disconnects do not close the Capture session; close
+            it with `DELETE /v1/sessions/{sessionId}` when finished.
 
     SessionStatus:
       type: string


### PR DESCRIPTION
## Summary
- Document `cdp: true` browser sessions and `connectUrl` usage in the browser sessions overview
- Update MCP docs to mention `browser_session_create` CDP support and incompatibilities
- Extend the sessions OpenAPI contract with CDP request/response fields and examples

## Validation
- `bun run openapi:validate`
- `bun run lint`
- `bun run types:check`
- `bun run build` started but hung at `Creating an optimized production build ...` twice; stopped after several minutes with no further output

Basecamp To-Do: https://app.basecamp.com/5890597/buckets/40504560/todos/10004189681