### PR TITLE
Fix docs search returning nothing (500 on /api/search in production)

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -5,6 +5,18 @@ const withMDX = createMDX();
 /** @type {import('next').NextConfig} */
 const config = {
   reactStrictMode: true,
+  // The OpenAPI spec lives in `public/` and is read from disk at runtime by
+  // `openapi.staticSource()` (see lib/source.ts). `public/` is not bundled into
+  // serverless functions by default, so on Vercel the file is missing and the
+  // module init throws, 500ing every route that imports `@/lib/source`
+  // (including /api/search and the /docs index). Trace the spec into those
+  // functions so the path resolves at runtime.
+  outputFileTracingIncludes: {
+    "/api/search": ["./public/openapi/**/*"],
+    "/docs/**": ["./public/openapi/**/*"],
+    "/llms-full.txt": ["./public/openapi/**/*"],
+    "/og/docs/**": ["./public/openapi/**/*"],
+  },
   images: {
     remotePatterns: [
       {


### PR DESCRIPTION
## Problem

Docs search renders but produces no results — typing a query does nothing. Reproduced on the live site: `GET https://docs.capture.page/api/search?query=...` returns **HTTP 500**, so the search dialog gets no data. The `/docs` index route also 500s. Statically prerendered doc pages (e.g. `/docs/get-started`) work fine.

## Root cause

`lib/source.ts` builds an OpenAPI source at module-init time:

```ts
const openapiSource = await openapi.staticSource({ ... });
```

`createOpenAPI({ input: ["./public/openapi/sessions.yaml"] })` reads that YAML from disk at runtime (`processDocument` → `@apidevtools/json-schema-ref-parser` `bundle(path)`). Next.js does **not** bundle the `public/` directory into serverless functions, so on Vercel the file is absent and the call throws `[OpenAPI] Failed to resolve input: ./public/openapi/sessions.yaml`. That crashes module init for **every route that imports `@/lib/source`** — including `/api/search` — yielding a 500 and an empty search UI.

It works under local `next start` only because the process runs from the project root, where `public/openapi/sessions.yaml` exists on disk.

## Fix

Add `outputFileTracingIncludes` in `next.config.mjs` so the OpenAPI spec is traced into the serverless functions that need it (search, docs, llms-full, OG image).

## Verification

- Production build (`bun run build`): the spec now appears in each function's `.nft.json` trace (`app/api/search/route`, `app/docs/[[...slug]]/page`, `app/llms-full.txt/route`, `app/og/docs/[...slug]/route` — all 1 match; previously 0 for search).
- `next start` against the production build: `/api/search?query=screenshot` → **200** with real results; `/docs/get-started` → 200.
- `biome check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)