### PR TITLE
Document CDP proxy browser sessions

### DIFF
--- a/content/docs/browser-sessions-overview.mdx
+++ b/content/docs/browser-sessions-overview.mdx
@@ -216,9 +216,19 @@ Disconnecting a CDP client does not close the Capture session. Close the
 session with `DELETE /v1/sessions/{sessionId}` when the workflow is finished so
 billing stops promptly.
 
-CDP sessions cannot be combined with `proxy` or `bypassBotDetection`. If you
-need either of those options, create a regular browser session and use Capture
-actions instead of a raw CDP connection.
+CDP sessions can be combined with `proxy: true` to route both the Capture-owned
+page and CDP-created targets through your configured browser proxy:
+
+```bash
+curl -X POST "https://api.capture.page/v1/sessions" \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{"cdp":true,"proxy":true,"maxTtlSeconds":300}'
+```
+
+CDP sessions cannot be combined with `bypassBotDetection`. If you need bot
+detection bypass, create a regular browser session and use Capture actions
+instead of a raw CDP connection.
 
 ## Action types
 

--- a/content/docs/mcp-integration.mdx
+++ b/content/docs/mcp-integration.mdx
@@ -148,7 +148,8 @@ Playwright `connectOverCDP`, then close the Capture session with
 `browser_session_close` when finished. Disconnecting the CDP client does not
 close the Capture session.
 
-`cdp` cannot be combined with `proxy` or `bypassBotDetection`.
+`cdp` can be combined with `proxy` when CDP-created targets need to use your
+configured proxy. `cdp` cannot be combined with `bypassBotDetection`.
 
 #### browser_session_act
 

--- a/public/openapi/sessions.yaml
+++ b/public/openapi/sessions.yaml
@@ -60,8 +60,9 @@ paths:
                   proxy: true
                   bypassBotDetection: true
               cdpWithProxy:
-                summary: 'Invalid: CDP cannot be combined with proxy'
+                summary: CDP session through the configured proxy
                 value:
+                  maxTtlSeconds: 300
                   cdp: true
                   proxy: true
       responses:
@@ -95,6 +96,18 @@ paths:
                       bypassBotDetection: false
                       cdp: true
                       connectUrl: wss://connect.capture.page/cdp?token=v1.example
+                cdpWithProxy:
+                  value:
+                    success: true
+                    session:
+                      id: sess_123e4567-e89b-12d3-a456-426614174000
+                      status: active
+                      expiresAt: '2026-06-17T11:20:00.000Z'
+                      maxTtlSeconds: 300
+                      proxy: true
+                      bypassBotDetection: false
+                      cdp: true
+                      connectUrl: wss://connect.capture.page/cdp?token=v1.example
         '400':
           description: Invalid session options
           content:
@@ -102,11 +115,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
               examples:
-                cdpWithProxy:
-                  summary: CDP cannot be combined with proxy or bypassBotDetection
+                cdpWithBypass:
+                  summary: CDP cannot be combined with bypassBotDetection
                   value:
                     success: false
-                    error: cdp cannot be combined with proxy or bypassBotDetection
+                    error: cdp cannot be combined with bypassBotDetection
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -398,8 +411,9 @@ components:
           default: false
           description: |
             Expose a Chrome DevTools Protocol connection URL for direct browser
-            automation clients. CDP sessions cannot be combined with `proxy` or
-            `bypassBotDetection` and require CDP connection support to be available.
+            automation clients. CDP sessions can be combined with `proxy` so CDP-created
+            targets use the authenticated user's configured proxy, but cannot be combined
+            with `bypassBotDetection`. CDP connection support must be available.
             The create response includes `session.cdp`; session metadata includes
             `session.options.cdp`.
 


### PR DESCRIPTION
## Summary
- update Browser Sessions docs to show that cdp + proxy is supported
- update MCP integration docs with the new CDP/proxy compatibility
- update the OpenAPI examples/schema to make cdp + proxy a 201 success case and cdp + bypassBotDetection the invalid case

## Test plan
- bun run openapi:validate

Amp-Thread-ID: https://ampcode.com/threads/T-019f0805-5e69-73be-be84-4af2175a8482